### PR TITLE
add default font size to use when PDF field size is set to 'auto'

### DIFF
--- a/examples/acroforms/forms.js
+++ b/examples/acroforms/forms.js
@@ -40,7 +40,7 @@ function setupForm(div, content, viewport) {
   function assignFontStyle(element, item) {
     var fontStyles = '';
     if ('fontSize' in item) {
-      fontStyles += 'font-size: ' + Math.round(item.fontSize *
+      fontStyles += 'font-size: ' + Math.round(item.fontSize ? item.fontSize : 12 *
                                                viewport.fontScale) + 'px;';
     }
     switch (item.textAlignment) {


### PR DESCRIPTION
The default "Auto" font size used by Adobe Acrobat when generating text fields was causing this line to generate a font size of 0, making text in the field invisible.
This patch assumes (dangerously?) a font size of 12 when this occurs.
